### PR TITLE
Sync cache

### DIFF
--- a/granolin.lisp
+++ b/granolin.lisp
@@ -61,7 +61,7 @@
    (sync-state
     :accessor sync-state
     :initform nil
-    :documentation "A SYNCED-STATE object, containing deserialized JSON retruned from SYNC."))
+    :documentation "A SYNC-STATE instance, containing deserialized JSON retruned from SYNC."))
   (:documentation "An instance of CLIENT holds the necessary state for
   interacting with a Matrix server. If HARDCOPY is supplied, the
   INITIALIZE-INSTANCE :after auxilliary method will attempt to populate the

--- a/granolin.lisp
+++ b/granolin.lisp
@@ -58,8 +58,8 @@
     :reader ssl
     :initform T
     :documentation "Set to nil to use http protocol.")
-   (synced
-    :accessor synced
+   (sync-state
+    :accessor sync-state
     :initform nil
     :documentation "A SYNCED-STATE object, containing deserialized JSON retruned from SYNC."))
   (:documentation "An instance of CLIENT holds the necessary state for

--- a/utils.lisp
+++ b/utils.lisp
@@ -9,3 +9,23 @@
              (equal #\@ (aref s 0)))
         (subseq s 1 stop-index)
         s)))
+
+(defun probably-plistp (ls)
+  (and (consp ls) (keywordp (car ls))))
+
+(defun update-json-plist (old new)
+  "Recursively update the plist OLD with the plist NEW. Destructively alters
+OLD, and returns it. Never removes any values, but can overwrite values whose
+keys are present in NEW "
+  (loop :for (key val . more) :on new :by #'cddr :do
+    (cond
+      ;; if the value is a plist, recurse
+      ((probably-plistp val)
+       (setf (getf old key)
+             (update-json-plist (getf old key) val)))
+      ;; otherwise the val is non "object", and so can just be updated if
+      ;; different
+      ((not (equal val (getf old key)))
+       (setf (getf old key) val))))
+  ;; return the updated old value
+  old)


### PR DESCRIPTION
At @gcentauri 's leisure, this is a suggestion to address caching the sync state.  If you think it seems like a fine approach, we can merge into develop.

Some things would need to be added before the approach is fully useful though: 
1. hook the `sync-state` field into the `hardcopy` functions, which write and restore state from disk into a new client instance.
2. change the behavior of `sync` to check whether or not to do a full sync based on the existence of the `sync-state` field in the client.

I have added the field without removing anything from the class so that current bots should work as-is.  This effort is just a kind of RFC, preliminary to future work.